### PR TITLE
Fix double header on index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,19 +17,11 @@
 
 		<!-- Wrapper -->
 			<div id="wrapper">
-
-				<!-- Placeholder for the header -->
-				<div id="header-placeholder"></div>
-
-				<!-- JavaScript to load the header -->
-				<script>
-					fetch('header.html')
-					.then(response => response.text())
-					.then(data => {
-						document.getElementById('header-placeholder').innerHTML = data;
-					})
-					.catch(error => console.error('Error loading header:', error));
-				</script>
+				
+			<!-- Header -->
+			<header id="header" class="alt">
+				<span class="logo"><img src="images/ICU_Heart_WoT_Rectangle_C_Aligned_20p.png" alt="ICU Heart logo: Routine data. Extraordinary results." /></span>
+			</header>
 
 				<!-- Nav -->
 					<nav id="nav">


### PR DESCRIPTION
Fix the double header. The header.html was made for the sub pages as they had no navigation functionality. However, index.html already has a nice animated header for navigation and having two makes the page look amateur-ish!