### PR TITLE
Fixes to papers tab

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3074,8 +3074,11 @@ input, select, textarea {
 /* Header */
 
 	#header {
-		padding: 5em 5em 1em 5em ;
+		padding: 10em 1em 1em 1em ; /* top right bottom left */
 		text-align: center;
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
 	}
 
 		#header h1 {

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 							<li><a href="#current-work">Current work</a></li>
 							<li><a href="#team">Team</a></li>
 							<li><a href="#blog">Blog</a></li>
-							<li><a href="#papers">Papers</a></li>
+							<li><a href="#papers-index">Papers</a></li>
 							<li><a href="#get-in-touch">Get in touch</a></li>
 						</ul>
 					</nav>

--- a/papers.html
+++ b/papers.html
@@ -32,6 +32,7 @@
 				</script>
 
 				<!-- Nav -->
+				<br> <!--need this to stop overlapping-->
 				<nav id="nav">
 					<ul>
 						<li><a href="#icu" class="active">ICU Papers</a></li>


### PR DESCRIPTION
Couple of minor fixes

- The link on the main page to the Papers section was broken, now fixed
- On the papers tab when loading the bottom navbar (Covid/ICU) would overlap the top main navbar. Now fixed by padding and css changes